### PR TITLE
chore: Update azure.yaml and main.parameters.json for Azure principal ID

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -2,14 +2,6 @@
 
 name: nlpsql-in-a-box
 hooks:
-  preprovision:
-    # sets the PRINCIPAL_ID environment variable to the signed-in user's id
-    windows:
-      shell: pwsh
-      run: azd env set PRINCIPAL_ID $(az ad signed-in-user show --query id -o tsv)
-    posix:
-      shell: sh
-      run: azd env set PRINCIPAL_ID $(az ad signed-in-user show --query id -o tsv)
   postprovision:
     # updates the .env file with the values from the azd environment
     windows:

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -9,7 +9,7 @@
         "value": "${AZURE_LOCATION}"
       },
       "principalId": {
-        "value": "${PRINCIPAL_ID}"
+        "value": "${AZURE_PRINCIPAL_ID}"
       },
       "ipAddress": {
         "value": "${IP_ADDRESS}"


### PR DESCRIPTION
This pull request includes several changes to the Azure configuration files to improve environment variable handling. The most important changes include removing the `preprovision` hook from `azure.yaml` and updating the `principalId` parameter in `infra/main.parameters.json`.

### Configuration changes:

* [`azure.yaml`](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L5-L12): Removed the `preprovision` hook that set the `PRINCIPAL_ID` environment variable for both Windows and POSIX systems.
* [`infra/main.parameters.json`](diffhunk://#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13L12-R12): Updated the `principalId` parameter to use `AZURE_PRINCIPAL_ID` instead of `PRINCIPAL_ID`.